### PR TITLE
fixes for latest rakudo 2015.03 - hopefully addresses #1

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -136,7 +136,7 @@ class Test::Builder { ... };
 #= Global Test::Builder singleton object
 my Test::Builder $TEST_BUILDER;
 
-class Test::Builder:<soh_cah_toa 0.0.1> {
+class Test::Builder:auth<soh_cah_toa>:ver<0.0.1> {
     #= Stack containing results of each test
     has Test::Builder::Test          @!results;
 
@@ -280,7 +280,10 @@ class Test::Builder:<soh_cah_toa 0.0.1> {
     }
 }
 
-END { $TEST_BUILDER.done unless $TEST_BUILDER.done_testing }
+END {
+    $TEST_BUILDER.done
+        if $TEST_BUILDER.defined && !$TEST_BUILDER.done_testing
+}
 
 # vim: ft=perl6
 

--- a/lib/Test/Builder/Output.pm
+++ b/lib/Test/Builder/Output.pm
@@ -97,7 +97,7 @@ class Test::Builder::Output;
     has $!stderr;    #= Filehandle used by diag()
 
     # XXX Can I just set default attribute values and remove BUILD()?
-    submethod BUILD($!stdout = $*OUT, $!stderr = $*ERR) { ... }
+    submethod BUILD($!stdout = $*OUT, $!stderr = $*ERR) { }
 
     #= Displays output to filehandle set by $.stdout
     method write(Str $msg is copy) {

--- a/lib/Test/Builder/Plan.pm
+++ b/lib/Test/Builder/Plan.pm
@@ -99,7 +99,7 @@ class Test::Builder::Plan does Test::Builder::Plan::Generic {
     has Int $.expected is rw;    #= Number of tests that "should" be run
 
     submethod BUILD(:$.expected = 0) {
-        die 'Invalid or missing plan!' unless $.expected.defined;
+        die 'Invalid or missing plan!' unless self.expected.defined;
     }
 
     #= Returns string to be displayed before tests are run


### PR DESCRIPTION
- minor changes to class syntax class Foo:ver<...>:auth<...>
- fix 'Cannot look up attributes in a type object' error
- fix 'stub code executed' error
